### PR TITLE
Adjust live trading risk thresholds

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -5,7 +5,7 @@
 ### 1. **Trading System Performance**
 - **Baseline Strategy**: 57.6% annual returns with realistic live trading system
 - **Enhanced ML Models**: Random Forest with technical indicators
-- **Risk Management**: 8% stop loss, 20% take profit, position sizing
+- **Risk Management**: 3% stop loss, 10% take profit, position sizing
 - **Real-time Integration**: Live Alpaca API connection confirmed
 
 ### 2. **Alpaca Integration** 

--- a/realistic_live_trading_system.py
+++ b/realistic_live_trading_system.py
@@ -65,8 +65,8 @@ class RealisticLiveTradingSystem:
             'exceptional_signal_threshold': 0.80,  # 80% for exceptional (was 0.75)
             'ultra_signal_threshold': 0.92,  # 92% for ultra confidence
             'min_position_size': 0.03,  # Min 3% per stock
-            'stop_loss_pct': 0.06,      # 6% stop loss (tighter - preserve capital)
-            'take_profit_pct': 0.20,    # 20% take profit (lock in gains faster)
+            'stop_loss_pct': 0.03,      # 3% stop loss (quick risk control)
+            'take_profit_pct': 0.10,    # 10% take profit (more achievable)
             'rebalance_threshold': 0.10, # 10% threshold for rebalancing
             'signal_threshold': 0.55,    # Higher minimum signal (was 0.25 - QUALITY OVER QUANTITY!)
             'max_positions': 6,         # Max 6 positions (was 8 - more concentrated)


### PR DESCRIPTION
## Summary
- Lower stop-loss to 3% and take-profit to 10% in realistic live trading config
- Update implementation summary to reflect new risk management targets

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a80cf716408329afcaab549e108ceb