### PR TITLE
Enhance model validation and cost-aware risk controls

### DIFF
--- a/algobot/sizing/position_sizer.py
+++ b/algobot/sizing/position_sizer.py
@@ -38,7 +38,7 @@ def kelly_fraction(win_rate: float, avg_win: float, avg_loss: float, fraction: f
         return 0.0
 
 
-def kelly_size(confidence: float, equity: float, price: float, cap_fraction: float = 0.50,
+def kelly_size(confidence: float, equity: float, price: float, cap_fraction: float = 0.15,
                win_rate: Optional[float] = None, avg_win: float = 0.08, avg_loss: float = 0.025,
                frac: float = 0.60) -> int:
     """Return integer shares using (fractional) Kelly sizing with a per-position cap.
@@ -49,7 +49,7 @@ def kelly_size(confidence: float, equity: float, price: float, cap_fraction: flo
         confidence: Proxy for win probability in [0,1] when win_rate not provided.
         equity: Account equity in dollars.
         price: Current asset price.
-        cap_fraction: Hard cap on position as a fraction of equity (e.g., 0.50 = 50% - AGGRESSIVE!).
+        cap_fraction: Hard cap on position as a fraction of equity (default 15% for prudence).
         win_rate: If provided, use as win probability; otherwise use confidence.
         avg_win: Assumed average win (fraction of price) - INCREASED TO 8%.
         avg_loss: Assumed average loss (fraction of price) - INCREASED TO 2.5%.


### PR DESCRIPTION
## Summary
- Add rolling cross-validation with holdout tracking for daily model training
- Skip trades when expected signal edge fails to exceed transaction costs
- Record benchmark buy-and-hold returns and compute excess return alongside portfolio metrics
- Introduce configurable per-symbol exposure cap and tighten default position limits
- Set conservative default cap for Kelly sizing

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa216aba78832986546369386f92be