### PR TITLE
Expand indicators and blend ML signals in scanner

### DIFF
--- a/tests/test_portfolio_scanner.py
+++ b/tests/test_portfolio_scanner.py
@@ -1,0 +1,21 @@
+import pandas as pd
+import numpy as np
+from algobot.portfolio import portfolio_scanner as ps
+
+
+def test_ml_signal_integration(monkeypatch):
+    # mock download to avoid network
+    def fake_download(symbol, start, end, use_local=True):
+        idx = pd.date_range('2024-01-01', periods=200)
+        close = pd.Series(np.linspace(100, 110, len(idx)), index=idx)
+        return close
+
+    monkeypatch.setattr(ps, '_download', fake_download)
+    monkeypatch.setattr(ps, '_strength_score', lambda close: 0.0)
+
+    res = ps.scan_universe(['AAPL'], thresholds=(0.5, -0.5), use_ml=True,
+                            ml_signals={'AAPL': 1.0}, ml_weight=1.0,
+                            use_local=False, write_json=False)
+    assert res['results']['AAPL']['classification'] == 'strong'
+    assert res['results']['AAPL']['ml_signal'] == 1.0
+    assert res['results']['AAPL']['combined_score'] == 1.0

--- a/tests/test_position_sizer.py
+++ b/tests/test_position_sizer.py
@@ -18,11 +18,12 @@ def test_kelly_integration():
     prices_today = {'AAPL': 100}
     signal = {'signal': 'BUY', 'strength': 0.6, 'price': 100}
     decision = system.make_human_like_decision('AAPL', signal, prices_today)
+    cap = min(system.config['max_position_size'], system.config['max_symbol_exposure'])
     expected = kelly_size(
         confidence=0.6,
         equity=system.current_capital,
         price=100,
-        cap_fraction=system.config['max_position_size'],
+        cap_fraction=cap,
     )
     assert decision['shares'] == expected
     assert decision['action'] == 'BUY'


### PR DESCRIPTION
## Summary
- Add ATR and multi-period momentum with rolling z-score normalization in `calculate_technical_indicators`
- Allow `scan_universe` to combine ML predictions with traditional strength scores and load per-symbol signals
- Test ML-signal blending in the portfolio scanner

## Testing
- `pip install numpy pandas scikit-learn lightgbm yfinance`
- `PYTHONPATH=. pytest tests/test_position_sizer.py -q`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa2065843483299359aa2cd5143096