### PR TITLE
Allow daily rebalancing and configurable training window

### DIFF
--- a/backtrader_system/strategies/elite_ml_strategy.py
+++ b/backtrader_system/strategies/elite_ml_strategy.py
@@ -89,7 +89,8 @@ class EliteMLTradingStrategy(bt.Strategy):
         ('trailing_stop_pct', 0.12), # Trailing stop percentage
         ('max_portfolio_heat', 0.30), # Maximum portfolio risk
         ('config', {}),              # ML configuration
-        ('rebalance_frequency', 5),  # Rebalance every N days
+        ('rebalance_frequency', 1),  # Rebalance every N days (default daily)
+        ('training_data_length', 730),  # Bars required for training
         ('volatility_filter', 0.05), # Max volatility for entry
         ('volume_filter', 0.8),      # Min volume ratio for entry
     )
@@ -118,7 +119,7 @@ class EliteMLTradingStrategy(bt.Strategy):
         
         # Training flags
         self.models_trained = False
-        self.training_data_length = 500  # Need 2+ years for training
+        self.training_data_length = self.params.training_data_length
         
         # Last rebalance date
         self.last_rebalance = None
@@ -216,7 +217,7 @@ class EliteMLTradingStrategy(bt.Strategy):
             self.logger.info(f"🧠 Training ML models for {len(symbols_ready)} symbols...")
             
             models_trained = 0
-            for symbol in symbols_ready[:10]:  # Train on first 10 symbols to save time
+            for symbol in symbols_ready:
                 try:
                     # Convert to DataFrame
                     df = pd.DataFrame(self.market_data[symbol])

--- a/elite_backtest_runner.py
+++ b/elite_backtest_runner.py
@@ -72,6 +72,11 @@ def main():
                        help='End date (YYYY-MM-DD)')
     parser.add_argument('--training-split', type=float, default=0.6,
                        help='Training data percentage (default: 0.6)')
+    parser.add_argument('--rebalance-frequency', type=int, default=1,
+                       help='Rebalance frequency in days (default: 1)')
+    parser.add_argument('--training-data-length', type=int, default=None,
+                       help='Number of bars required for training each symbol. '
+                            'Defaults to max(training split days, 730)')
     
     args = parser.parse_args()
     
@@ -107,12 +112,18 @@ def main():
         end_date = pd.to_datetime(args.end_date)
         total_days = (end_date - start_date).days
         training_days = int(total_days * args.training_split)
-        
+
         training_end = start_date + timedelta(days=training_days)
-        
+
+        if args.training_data_length is not None:
+            training_data_length = args.training_data_length
+        else:
+            training_data_length = max(training_days, 730)
+
         logger.info(f"📊 Data Periods:")
         logger.info(f"   Training: {start_date.date()} to {training_end.date()}")
         logger.info(f"   Testing: {training_end.date()} to {end_date.date()}")
+        logger.info(f"   Training data length: {training_data_length} bars")
         
         # Download data for symbols
         logger.info(f"📈 Downloading data for {len(args.symbols)} symbols...")
@@ -255,7 +266,8 @@ def main():
             'trailing_stop_pct': 0.12,     # 12% trailing stop
             'max_portfolio_heat': 0.30,    # Maximum 30% portfolio risk
             'config': config,
-            'rebalance_frequency': 5,      # Rebalance every 5 days
+            'rebalance_frequency': args.rebalance_frequency,
+            'training_data_length': training_data_length,
             'volatility_filter': 0.05,     # Max 5% volatility for entry
             'volume_filter': 0.8,          # Min 80% volume ratio
         }


### PR DESCRIPTION
## Summary
- expose `--rebalance-frequency` and `--training-data-length` options in `elite_backtest_runner.py`
- update `EliteMLTradingStrategy` to honor new parameters and train all symbols
- default daily rebalancing with flexible training window

## Testing
- `pytest` *(fails: No module named 'pandas')*
- `python elite_backtest_runner.py --symbols AAPL MSFT NVDA --start-date 2023-01-01 --end-date 2024-04-01 --rebalance-frequency 1 --training-data-length 30` *(terminates early due to KeyboardInterrupt after repeated training errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aaaaa77708832984f268c18567337d